### PR TITLE
[WIP]メッセージ送信機能の非同期化

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,15 @@
+$(function(){
+  $('#new_message').on('submit',function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+  })
+})

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -14,7 +14,7 @@
   .messages
     = render @messages
   .form
-    = form_for [@group, @message] do |f|
+    = form_for [@group, @message], id:"new_message" do |f|
       .new_message
         .input-box
           = f.text_field :body, class: 'input-box__text', placeholder: "type a message"


### PR DESCRIPTION
#WAHT
message機能をajaxで非同期化する。
#WHY
現在メッセージを送信すると再読み込みがされて使いづらいのでUX向上のため。